### PR TITLE
Inspect error reason before logging

### DIFF
--- a/lib/crawler/parser.ex
+++ b/lib/crawler/parser.ex
@@ -90,7 +90,7 @@ defmodule Crawler.Parser do
   """
   def parse(input)
 
-  def parse({:error, reason}), do: Logger.debug(reason)
+  def parse({:error, reason}), do: Logger.debug("#{inspect reason}")
   def parse(%{body: body, opts: opts} = page) do
     parse_links(body, opts, &Dispatcher.dispatch(&1, &2))
 

--- a/lib/crawler/parser.ex
+++ b/lib/crawler/parser.ex
@@ -90,7 +90,7 @@ defmodule Crawler.Parser do
   """
   def parse(input)
 
-  def parse({:error, reason}), do: Logger.debug("#{inspect reason}")
+  def parse({:error, reason}), do: Logger.debug(fn -> "#{inspect(reason)}" end)
   def parse(%{body: body, opts: opts} = page) do
     parse_links(body, opts, &Dispatcher.dispatch(&1, &2))
 


### PR DESCRIPTION
I was getting a `(Protocol.UndefinedError) protocol String.Chars not implemented for {:already_registered, #PID}` error when re-running the crawler, so I added a `Kernel.inspect/1` call when logging the error in the default parser.