### PR TITLE
Added option to encode URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are several ways to access the crawled page data:
 | `:retrier`      | module  | `Crawler.Fetcher.Retrier`   | Custom fetch retrier, useful for retrying failed crawls.
 | `:scraper`      | module  | `Crawler.Scraper`           | Custom scraper, useful for scraping content as soon as the parser parses it.
 | `:parser`       | module  | `Crawler.Parser`            | Custom parser, useful for handling parsing differently or to add extra functionalities.
+| `:encode_uri`   | boolean | `false`                     | When set to `true` apply the `URI.encode` to the URL to be crawled.
 
 ## Custom Modules
 

--- a/lib/crawler/options.ex
+++ b/lib/crawler/options.ex
@@ -16,6 +16,7 @@ defmodule Crawler.Options do
   @retrier    Crawler.Fetcher.Retrier
   @scraper    Crawler.Scraper
   @parser     Crawler.Parser
+  @encode     false
 
   @doc """
   Assigns default option values.
@@ -46,6 +47,7 @@ defmodule Crawler.Options do
       retrier:    retrier(),
       scraper:    scraper(),
       parser:     parser(),
+      encode_uri: encode_uri(),
     }, opts)
   end
 
@@ -63,6 +65,9 @@ defmodule Crawler.Options do
       iex> Options.assign_url(%{url: "http://example.com/"}, "http://options/")
       %{url: "http://options/"}
   """
+  def assign_url(%{encode_uri: true} = opts, url) do
+    Map.merge(opts, %{url: URI.encode(url)})
+  end
   def assign_url(opts, url) do
     Map.merge(opts, %{url: url})
   end
@@ -78,4 +83,5 @@ defmodule Crawler.Options do
   defp retrier,    do: Application.get_env(:crawler, :retrier,    @retrier)
   defp scraper,    do: Application.get_env(:crawler, :scraper,    @scraper)
   defp parser,     do: Application.get_env(:crawler, :parser,     @parser)
+  defp encode_uri, do: Application.get_env(:crawler, :encode_uri, @encode_uri)
 end


### PR DESCRIPTION
Added the possibility to encode the URL passed to `Crawler.crawl` when given the option `encode: true`. This could solve issue #12 