### PR TITLE
Moved `plug_cowboy` to test env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Crawler.Mixfile do
       {:floki,       "~> 0.18"},
       {:opq,         "~> 3.0"},
       {:retry,       "~> 0.10"},
-      {:plug_cowboy, "~> 1.0"},
+      {:plug_cowboy, "~> 1.0",   only: :test},
       {:ex_doc,      ">= 0.0.0", only: :dev},
       {:dialyxir,    "~> 0.5",   only: [:dev, :test], runtime: false},
       {:bypass,      "~> 0.8",   only: :test},


### PR DESCRIPTION
I tested this where `Mix.env == :dev` and was successfully able to crawl pages. The test suite passes as well. 

At the moment, this is not a mergeable PR. As commented by issue #22 , I will update the test dependency to `~> 2.0` but that involves altering the test suite due to changes to cowboy.