### PR TITLE
use ets instead of registry for store

### DIFF
--- a/lib/crawler.ex
+++ b/lib/crawler.ex
@@ -13,7 +13,7 @@ defmodule Crawler do
   - a `Crawler.Store` that initiates a `Registry` for keeping internal data
   """
   def start(_type, _args) do
-    {:ok, _pid} = Store.init()
+    {:ok, _pid} = Store.start_link()
   end
 
   @doc """

--- a/lib/crawler/store.ex
+++ b/lib/crawler/store.ex
@@ -92,4 +92,12 @@ defmodule Crawler.Store do
   Marks a URL as processed in the registry.
   """
   def processed(url), do: update(url, %{processed: true})
+
+  @doc """
+  clear the store of all the pages.
+  Useful for periodic crawl tasks.
+  """
+  def reset() do
+    :ets.delete_all_objects(@table)
+  end
 end


### PR DESCRIPTION
Here is my reasoning.
- using the store as a registry, means the process mailbox can become full and lead to a bottleneck.
- The advantage of having a registry here is that it is distributed. Deploying the crawler in a distributed fashion raises additional questions, so I have opted out of that path. (instead of ets it would be possible to use mnesia, which is slower but distributed)
- I added a store.reset method for periodic crawling tasks. (i.e. I want to check the content of the same pages everyday)
- running some tests on my local, the next bottleneck comes from hackney
https://github.com/edgurgel/httpoison/issues/359

My original issue was running into this actually.

In order to increase performance, the connection pool has to be managed in a different way. I'm currently researching this.

Let me know what you think
