### PR TITLE
Update Floki version in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Crawler.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 1.5"},
-      {:floki, "~> 0.25"},
+      {:floki, "~> 0.30"},
       {:opq, "~> 3.0"},
       {:retry, "~> 0.10"},
       {:plug_cowboy, "~> 2.0", only: :test},


### PR DESCRIPTION
This is just to match the new minimum version of Floki used in Phoenix 1.7 projects so we don't need to use override. Floki appears to only be used in the Crawler.Parser.HtmlParser module and the functions _Floki.parse_document/1_ and _Floki.find/2_ behave the same in both the 0.25 and 0.30 versions and up to v0.34.  We don't need to update the mix.lock as it is already set to v0.31.