### PR TITLE
Restore extra_applications back to [:logger] only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Crawler.Mixfile do
   def application do
     [
       mod: {Crawler, []},
-      extra_applications: [:logger, :runtime_tools, :observer, :wx]
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
It seems you accidentally added [:runtime_tools, :observer, :wx] to you extra_applications in mix.exs while you were debugging.

It breaks on some system that do not have the required graphical library for debugging.


Cheers!